### PR TITLE
Feat: Removed sql-ts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     env:
       MYSQL_DB_DATABASE: keyv_test
@@ -56,6 +56,7 @@ jobs:
         sudo -u postgres psql --command="ALTER ROLE postgres WITH PASSWORD 'postgres';" --command="\du"
         sudo systemctl restart postgresql.service
         pg_isready
+
     - run: yarn install
     - run: yarn test
     - name: Report

--- a/package.json
+++ b/package.json
@@ -2,19 +2,20 @@
   "name": "@keyvhq/mono",
   "private": "true",
   "devDependencies": {
-    "@keyvhq/keyv": "./packages/keyv",
-    "@keyvhq/keyv-mongo": "./packages/keyv-mongo",
-    "@keyvhq/keyv-mysql": "./packages/keyv-mysql",
-    "@keyvhq/keyv-postgres": "./packages/keyv-postgres",
-    "@keyvhq/keyv-redis": "./packages/keyv-redis",
-    "@keyvhq/keyv-sql": "./packages/keyv-sql",
-    "@keyvhq/keyv-sqlite": "./packages/keyv-sqlite",
-    "@keyvhq/keyv-test-suite": "./packages/keyv-test-suite",
+    "@keyvhq/keyv": "file:./packages/keyv",
+    "@keyvhq/keyv-mongo": "file:packages/keyv-mongo",
+    "@keyvhq/keyv-mysql": "file:packages/keyv-mysql",
+    "@keyvhq/keyv-postgres": "file:packages/keyv-postgres",
+    "@keyvhq/keyv-redis": "file:packages/keyv-redis",
+    "@keyvhq/keyv-sql": "file:packages/keyv-sql",
+    "@keyvhq/keyv-sqlite": "file:packages/keyv-sqlite",
+    "@keyvhq/keyv-test-suite": "file:packages/keyv-test-suite",
     "ava": "^3.15.0",
     "coveralls": "^3.0.0",
     "delay": "^4.3.0",
     "dotenv": "^8.2.0",
     "eslint-config-xo-lukechilds": "^1.0.0",
+    "knex": "^0.95.4",
     "lerna": "^4.0.0",
     "nyc": "^15.1.0",
     "pify": "^5.0.0",
@@ -31,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url" : "git+https://github.com/keyvhq/keyv.git"
+    "url": "git+https://github.com/keyvhq/keyv.git"
   },
   "keywords": [
     "keyv",

--- a/packages/keyv-mysql/package.json
+++ b/packages/keyv-mysql/package.json
@@ -37,8 +37,5 @@
     "@keyvhq/keyv-sql": "file:../keyv-sql",
     "mysql2": "2.2.5"
   },
-  "devDependencies": {
-    "@keyvhq/keyv-test-suite": "file:../keyv-test-suite"
-  },
   "gitHead": "a4e2c1f285236a753de13eb8a42d9a98690526cc"
 }

--- a/packages/keyv-sql/package.json
+++ b/packages/keyv-sql/package.json
@@ -4,7 +4,7 @@
   "description": "Parent class for SQL based Keyv storage adapters",
   "main": "src/index.js",
   "scripts": {
-    "test": "xo && nyc --no-clean --temp-dir ../../.nyc_output ava"
+    "test": "ava"
   },
   "xo": {
     "extends": "xo-lukechilds"
@@ -31,11 +31,5 @@
     "url": "https://github.com/keyvhq/keyv/issues"
   },
   "homepage": "https://github.com/keyvhq/keyv",
-  "dependencies": {
-    "sql-ts": "^5.2.0"
-  },
-  "devDependencies": {
-    "@keyvhq/keyv-test-suite": "file:../keyv-test-suite"
-  },
   "gitHead": "a4e2c1f285236a753de13eb8a42d9a98690526cc"
 }

--- a/packages/keyv-sql/test/test.js
+++ b/packages/keyv-sql/test/test.js
@@ -31,13 +31,9 @@ class TestSqlite extends KeyvSql {
 
 const store = () => new TestSqlite();
 keyvTestSuite(test, Keyv, store);
-
-test('Default key data type is VARCHAR(255)', t => {
-	const store = new TestSqlite();
-	t.is(store.entry.key.dataType, 'VARCHAR(255)');
-});
-
-test('keySize option overrides default', t => {
-	const store = new TestSqlite({ keySize: 100 });
-	t.is(store.entry.key.dataType, 'VARCHAR(100)');
-});
+const keyv = store();
+test.serial(`basic`, async(t) => {
+	const keyv = new Keyv({ store: store() });
+	await keyv.set('foo', 0);
+	t.is(await keyv.get('foo'), 0)
+})

--- a/packages/keyv-sqlite/package.json
+++ b/packages/keyv-sqlite/package.json
@@ -37,11 +37,5 @@
     "pify": "5.0.0",
     "sqlite3": "^5.0.2"
   },
-  "devDependencies": {
-    "@keyvhq/keyv-test-suite": "file:../keyv-test-suite"
-  },
-  "directories": {
-    "test": "test"
-  },
   "gitHead": "a4e2c1f285236a753de13eb8a42d9a98690526cc"
 }


### PR DESCRIPTION
queries are built manually by the keyv-sql package instead of depending on external packages

Signed-off-by: Jytesh <44925963+Jytesh@users.noreply.github.com>

Fixes #2, Fixes https://github.com/lukechilds/keyv-sql/issues/26

sql-ts is not compatible with node v10.