### PR TITLE
feat: allow to use an empty namespace

### DIFF
--- a/packages/keyv-mongo/src/index.js
+++ b/packages/keyv-mongo/src/index.js
@@ -96,13 +96,13 @@ class KeyvMongo extends EventEmitter {
 
 	clear() {
 		return this.connect
-			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace}`) })
+			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace ? this.namespace + ':' : '.*'}`) })
 				.then(() => undefined));
 	}
 
 	async * iterator() {
 		const iterator = await this.connect
-			.then(store => store.find({ key: new RegExp(`^${this.namespace}`) }).map(x => {
+			.then(store => store.find({ key: new RegExp(`^${this.namespace ? this.namespace + ':' : '.*'}`) }).map(x => {
 				return [x.key, x.value];
 			}));
 		yield * iterator;

--- a/packages/keyv-mongo/src/index.js
+++ b/packages/keyv-mongo/src/index.js
@@ -96,13 +96,13 @@ class KeyvMongo extends EventEmitter {
 
 	clear() {
 		return this.connect
-			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace}:`) })
+			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace}`) })
 				.then(() => undefined));
 	}
 
 	async * iterator() {
 		const iterator = await this.connect
-			.then(store => store.find({ key: new RegExp(`^${this.namespace}:`) }).map(x => {
+			.then(store => store.find({ key: new RegExp(`^${this.namespace}`) }).map(x => {
 				return [x.key, x.value];
 			}));
 		yield * iterator;

--- a/packages/keyv-mongo/src/index.js
+++ b/packages/keyv-mongo/src/index.js
@@ -96,7 +96,7 @@ class KeyvMongo extends EventEmitter {
 
 	clear() {
 		return this.connect
-			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace ? this.namespace + ':' : '.*'}`) })
+			.then(store => store.deleteMany({ key: new RegExp(`^${this.namespace + ':'}`) })
 				.then(() => undefined));
 	}
 

--- a/packages/keyv-redis/package.json
+++ b/packages/keyv-redis/package.json
@@ -34,7 +34,8 @@
   },
   "homepage": "https://github.com/keyvhq/keyv",
   "dependencies": {
-    "ioredis": "~4.17.1"
+    "ioredis": "~4.17.1",
+    "p-event": "~4.2.0"
   },
   "gitHead": "a4e2c1f285236a753de13eb8a42d9a98690526cc"
 }

--- a/packages/keyv-redis/src/index.js
+++ b/packages/keyv-redis/src/index.js
@@ -43,11 +43,6 @@ class KeyvRedis extends EventEmitter {
 	}
 
 	async clear() {
-		if (!this.namespace) {
-			await this.redis.flushall();
-			return undefined;
-		}
-
 		const stream = this.redis.scanStream({ match: `${this.namespace}:*` });
 
 		const keys = [];

--- a/packages/keyv-redis/src/index.js
+++ b/packages/keyv-redis/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const EventEmitter = require('events');
+const pEvent = require('p-event');
 const Redis = require('ioredis');
-const pify = require('pify');
 
 class KeyvRedis extends EventEmitter {
 	constructor(uri, options) {
@@ -11,60 +11,55 @@ class KeyvRedis extends EventEmitter {
 		if (uri instanceof Redis) {
 			this.redis = uri;
 		} else {
-			options = Object.assign({}, typeof uri === 'string' ? { uri } : uri, options);
+			options = Object.assign(
+				{},
+				typeof uri === 'string' ? { uri } : uri,
+				options
+			);
 			this.redis = new Redis(options.uri, options);
 		}
 
 		this.redis.on('error', error => this.emit('error', error));
 	}
 
-	_getNamespace() {
-		return `namespace:${this.namespace}`;
+	async get(key) {
+		const value = await this.redis.get(key);
+		return value === null ? undefined : value;
 	}
 
-	get(key) {
-		return this.redis.get(key)
-			.then(value => {
-				if (value === null) {
-					return undefined;
-				}
-
-				return value;
-			});
-	}
-
-	set(key, value, ttl) {
+	async set(key, value, ttl) {
 		if (typeof value === 'undefined') {
-			return Promise.resolve(undefined);
+			return undefined;
 		}
 
-		return Promise.resolve()
-			.then(() => {
-				if (typeof ttl === 'number') {
-					return this.redis.set(key, value, 'PX', ttl);
-				}
-
-				return this.redis.set(key, value);
-			})
-			.then(() => this.redis.sadd(this._getNamespace(), key));
+		return typeof ttl === 'number' ?
+			this.redis.set(key, value, 'PX', ttl) :
+			this.redis.set(key, value);
 	}
 
-	delete(key) {
-		return this.redis.del(key)
-			.then(items => {
-				return this.redis.srem(this._getNamespace(), key)
-					.then(() => items > 0);
-			});
+	async delete(key) {
+		const result = await this.redis.unlink(key);
+		return result > 0;
 	}
 
-	clear() {
-		return this.redis.smembers(this._getNamespace())
-			.then(keys => this.redis.del(keys.concat(this._getNamespace())))
-			.then(() => undefined);
+	async clear() {
+		if (!this.namespace) {
+			await this.redis.flushall();
+			return undefined;
+		}
+
+		const stream = this.redis.scanStream({ match: `${this.namespace}:*` });
+
+		const keys = [];
+		stream.on('data', matchedKeys => keys.push(...matchedKeys));
+		await pEvent(stream, 'end');
+		if (keys.length > 0) {
+			await this.redis.unlink(keys);
+		}
 	}
 
 	async * iterator() {
-		const scan = pify(this.redis.scan).bind(this.redis);
+		const scan = this.redis.scan.bind(this.redis);
 		const get = this.redis.mget.bind(this.redis);
 		async function * iterate(curs, pattern) {
 			const [cursor, keys] = await scan(curs, 'MATCH', pattern);
@@ -82,7 +77,7 @@ class KeyvRedis extends EventEmitter {
 			}
 		}
 
-		yield * iterate(0, `${this.namespace}:*`);
+		yield * iterate(0, `${this.namespace ? this.namespace + ':' : ''}*`);
 	}
 }
 

--- a/packages/keyv-sql/src/index.js
+++ b/packages/keyv-sql/src/index.js
@@ -65,14 +65,14 @@ class KeyvSql extends EventEmitter {
 	}
 
 	clear() {
-		const del = this.options.dialect === 'mysql' ? `DELETE FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}%')` : `DELETE FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}%')`;
+		const del = this.options.dialect === 'mysql' ? `DELETE FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace ? this.namespace + ':' : ''}%')` : `DELETE FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace ? this.namespace + ':' : ''}%')`;
 		return this.query(del)
 			.then(() => undefined);
 	}
 
 	async * iterator() {
 		const limit = Number.parseInt(this.options.iterationLimit, 10);
-		const selectChunk = this.options.dialect === 'mysql' ? `SELECT * FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}%') LIMIT ${limit} OFFSET ` : `SELECT * FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}%') LIMIT ${limit} OFFSET `;
+		const selectChunk = this.options.dialect === 'mysql' ? `SELECT * FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace ? this.namespace + ':' : ''}%') LIMIT ${limit} OFFSET ` : `SELECT * FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace ? this.namespace + ':' : ''}%') LIMIT ${limit} OFFSET `;
 
 		async function * iterate(offset, query) {
 			const entries = await query(selectChunk + offset);

--- a/packages/keyv-sql/src/index.js
+++ b/packages/keyv-sql/src/index.js
@@ -65,14 +65,14 @@ class KeyvSql extends EventEmitter {
 	}
 
 	clear() {
-		const del = this.options.dialect === 'mysql' ? `DELETE FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}:%')` : `DELETE FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}:%')`;
+		const del = this.options.dialect === 'mysql' ? `DELETE FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}%')` : `DELETE FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}%')`;
 		return this.query(del)
 			.then(() => undefined);
 	}
 
 	async * iterator() {
 		const limit = Number.parseInt(this.options.iterationLimit, 10);
-		const selectChunk = this.options.dialect === 'mysql' ? `SELECT * FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}:%') LIMIT ${limit} OFFSET ` : `SELECT * FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}:%') LIMIT ${limit} OFFSET `;
+		const selectChunk = this.options.dialect === 'mysql' ? `SELECT * FROM \`${this.options.table}\` WHERE (\`${this.options.table}\`.\`key\` LIKE '${this.namespace}%') LIMIT ${limit} OFFSET ` : `SELECT * FROM "${this.options.table}" WHERE ("${this.options.table}"."key" LIKE '${this.namespace}%') LIMIT ${limit} OFFSET `;
 
 		async function * iterate(offset, query) {
 			const entries = await query(selectChunk + offset);

--- a/packages/keyv-test-suite/src/api.js
+++ b/packages/keyv-test-suite/src/api.js
@@ -67,6 +67,7 @@ const keyvApiTests = (test, Keyv, store) => {
 
 	test.serial('.delete(key) with nonexistent key resolves to false', async t => {
 		const keyv = new Keyv({ store: store() });
+		t.is(await keyv.delete(), false);
 		t.is(await keyv.delete('foo'), false);
 	});
 

--- a/packages/keyv-test-suite/src/index.js
+++ b/packages/keyv-test-suite/src/index.js
@@ -1,19 +1,19 @@
 const keyvApiTests = require('./api.js');
 const keyvValueTests = require('./values.js');
-const keyvNamepsaceTests = require('./namespace.js');
+const keyvNamespaceTests = require('./namespace.js');
 const keyvIteratorTests = require('./iteration.js');
 
 const keyvTestSuite = (test, Keyv, store) => {
 	keyvIteratorTests(test, Keyv, store);
 	keyvApiTests(test, Keyv, store);
 	keyvValueTests(test, Keyv, store);
-	keyvNamepsaceTests(test, Keyv, store);
+	keyvNamespaceTests(test, Keyv, store);
 };
 
 Object.assign(keyvTestSuite, {
 	keyvApiTests,
 	keyvValueTests,
-	keyvNamepsaceTests,
+	keyvNamespaceTests,
 	keyvIteratorTests
 });
 

--- a/packages/keyv-test-suite/src/namespace.js
+++ b/packages/keyv-test-suite/src/namespace.js
@@ -39,6 +39,20 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 		t.is(await keyv2.get('bar'), 'keyv2');
 	});
 
+	test.serial('no namespaced clear clears all stores', async t => {
+		const keyv1 = new Keyv({ store: store(), namespace: false });
+		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		await keyv1.set('foo', 'keyv1');
+		await keyv1.set('bar', 'keyv1');
+		await keyv2.set('foo', 'keyv2');
+		await keyv2.set('bar', 'keyv2');
+		await keyv1.clear();
+		t.is(await keyv1.get('foo'), undefined);
+		t.is(await keyv1.get('bar'), undefined);
+		t.is(await keyv2.get('foo'), undefined);
+		t.is(await keyv2.get('bar'), undefined);
+	});
+
 	test.after.always(async () => {
 		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
 		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });

--- a/packages/keyv-test-suite/src/namespace.js
+++ b/packages/keyv-test-suite/src/namespace.js
@@ -39,7 +39,7 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 		t.is(await keyv2.get('bar'), 'keyv2');
 	});
 
-	test.serial('no namespaced clear clears all stores', async t => {
+	test.serial('no namespaced clear doesn\'t clears all stores', async t => {
 		const keyv1 = new Keyv({ store: store(), namespace: false });
 		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
 		await keyv1.set('foo', 'keyv1');
@@ -47,10 +47,10 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 		await keyv2.set('foo', 'keyv2');
 		await keyv2.set('bar', 'keyv2');
 		await keyv1.clear();
-		t.is(await keyv1.get('foo'), undefined);
-		t.is(await keyv1.get('bar'), undefined);
-		t.is(await keyv2.get('foo'), undefined);
-		t.is(await keyv2.get('bar'), undefined);
+		t.is(await keyv1.get('foo'), 'keyv1');
+		t.is(await keyv1.get('bar'), 'keyv1');
+		t.is(await keyv2.get('foo'), 'keyv2');
+		t.is(await keyv2.get('bar'), 'keyv2');
 	});
 
 	test.after.always(async () => {

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyvhq/keyv",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Simple key-value storage with support for multiple backends",
   "main": "src/index.js",
   "scripts": {

--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -16,6 +16,7 @@ class Keyv extends EventEmitter {
 		);
 
 		this.store = this.options.store;
+		this.store.namespace = this.options.namespace;
 
 		if (!this.store) {
 			this.store = new Map();
@@ -24,8 +25,6 @@ class Keyv extends EventEmitter {
 		if (typeof this.store.on === 'function') {
 			this.store.on('error', error => this.emit('error', error));
 		}
-
-		this.store.namespace = this.options.namespace ? this.options.namespace + ':' : '';
 
 		const generateIterator = iterator => async function * () {
 			for await (const [key, raw] of (typeof iterator === 'function' ? iterator() : iterator)) {
@@ -54,11 +53,11 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
-		return this.opts.namespace ? `${this.opts.namespace}:${key}` : key;
+		return this.options.namespace ? `${this.options.namespace}:${key}` : key;
 	}
 
 	_getKeyUnprefix(key) {
-		return key.split(':').splice(1).join(':');
+		return this.options.namespace ? key.split(':').splice(1).join(':') : key;
 	}
 
 	get(key, options) {

--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -25,7 +25,7 @@ class Keyv extends EventEmitter {
 			this.store.on('error', error => this.emit('error', error));
 		}
 
-		this.store.namespace = this.options.namespace;
+		this.store.namespace = this.options.namespace ? this.options.namespace + ':' : '';
 
 		const generateIterator = iterator => async function * () {
 			for await (const [key, raw] of (typeof iterator === 'function' ? iterator() : iterator)) {

--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -54,7 +54,7 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
-		return `${this.options.namespace}:${key}`;
+		return this.opts.namespace ? `${this.opts.namespace}:${key}` : key;
 	}
 
 	_getKeyUnprefix(key) {

--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -16,11 +16,12 @@ class Keyv extends EventEmitter {
 		);
 
 		this.store = this.options.store;
-		this.store.namespace = this.options.namespace;
 
 		if (!this.store) {
 			this.store = new Map();
 		}
+
+		this.store.namespace = this.options.namespace;
 
 		if (typeof this.store.on === 'function') {
 			this.store.on('error', error => this.emit('error', error));
@@ -111,6 +112,10 @@ class Keyv extends EventEmitter {
 	}
 
 	clear() {
+		if (!this.options.namespace) {
+			return Promise.resolve().then(() => undefined);
+		}
+
 		const store = this.store;
 		return Promise.resolve()
 			.then(() => store.clear());

--- a/packages/keyv/test/keyv.js
+++ b/packages/keyv/test/keyv.js
@@ -124,5 +124,26 @@ test.serial('Keyv supports async serializer/deserializer', async t => {
 	t.is(await keyv.get('foo'), 'bar');
 });
 
+test.serial('Keyv uses a default namespace', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store });
+	await keyv.set('foo', 'bar');
+	t.is([...store.keys()][0], 'keyv:foo');
+});
+
+test.serial('Default namespace can be overridden', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: 'magic' });
+	await keyv.set('foo', 'bar');
+	t.is([...store.keys()][0], 'magic:foo');
+});
+
+test.serial('An empty namespace stores the key as-is', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: '' });
+	await keyv.set(42, 'foo');
+	t.is([...store.keys()][0], 42);
+});
+
 const store = () => new Map();
 keyvTestSuite(test, Keyv, store);


### PR DESCRIPTION
@Kikobeats I am not sure how redis namespaces work, but I think empty namespaces will break the current redis store so can you update it?